### PR TITLE
MEN-2791: Build and upload grub-efi binaries

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,7 +1,9 @@
 variables:
+  GRUB_VERSION: '2.04'
   DOCKER_REPOSITORY: mendersoftware/mender-convert-integration-scripts
   S3_BUCKET_NAME: mender
-  S3_BUCKET_PATH: "mender-convert/uboot"
+  S3_BUCKET_PATH_UBOOT: "mender-convert/uboot"
+  S3_BUCKET_PATH_GRUB: "mender-convert/grub-efi"
 
 include:
   - project: 'Northern.tech/Mender/mendertesting'
@@ -14,7 +16,7 @@ stages:
   - build
   - publish
 
-build:
+build:uboot:
   stage: build
   image: docker
   services:
@@ -28,40 +30,83 @@ build:
     paths:
       - output/*
 
+build:grub-efi:
+  stage: build
+  image: docker
+  services:
+    - docker:dind
+  before_script:
+    - apk --update --no-cache add sudo libc6-compat
+  script:
+    - (cd grub-efi && GRUB_VERSION=$GRUB_VERSION ./docker-create-grub-efi-binaries)
+  artifacts:
+    expire_in: 2w
+    paths:
+      - grub-efi/output/*
+
 publish:s3:
   stage: publish
   image: debian:buster
   dependencies:
-    - build
+    - build:uboot
+    - build:grub-efi
   before_script:
     - apt update && apt install -yyq awscli
     - UBOOT_MENDER_BRANCH_BBB=$(grep ^UBOOT_MENDER_BRANCH= build-uboot-bbb.sh | cut -d= -f2)
     - UBOOT_MENDER_BRANCH_RPI=$(grep ^UBOOT_MENDER_BRANCH= build-uboot-rpi.sh | cut -d= -f2)
   script:
+    # U-Boot binaries
     - echo "Publishing uboot for beaglebone_black_debian_emmc version ${UBOOT_MENDER_BRANCH_BBB}"
     - aws s3 cp output/beaglebone_black_debian_emmc-${UBOOT_MENDER_BRANCH_BBB}.tar
-        s3://$S3_BUCKET_NAME/$S3_BUCKET_PATH/beaglebone/beaglebone_black_debian_emmc-${UBOOT_MENDER_BRANCH_BBB}.tar
+        s3://$S3_BUCKET_NAME/$S3_BUCKET_PATH_UBOOT/beaglebone/beaglebone_black_debian_emmc-${UBOOT_MENDER_BRANCH_BBB}.tar
     - aws s3api put-object-acl --acl public-read --bucket $S3_BUCKET_NAME
-        --key $S3_BUCKET_PATH/beaglebone/beaglebone_black_debian_emmc-${UBOOT_MENDER_BRANCH_BBB}.tar
+        --key $S3_BUCKET_PATH_UBOOT/beaglebone/beaglebone_black_debian_emmc-${UBOOT_MENDER_BRANCH_BBB}.tar
     - echo "Publishing uboot for beaglebone_black_debian_sdcard version ${UBOOT_MENDER_BRANCH_BBB}"
     - aws s3 cp output/beaglebone_black_debian_sdcard-${UBOOT_MENDER_BRANCH_BBB}.tar
-        s3://$S3_BUCKET_NAME/$S3_BUCKET_PATH/beaglebone/beaglebone_black_debian_sdcard-${UBOOT_MENDER_BRANCH_BBB}.tar
+        s3://$S3_BUCKET_NAME/$S3_BUCKET_PATH_UBOOT/beaglebone/beaglebone_black_debian_sdcard-${UBOOT_MENDER_BRANCH_BBB}.tar
     - aws s3api put-object-acl --acl public-read --bucket $S3_BUCKET_NAME
-        --key $S3_BUCKET_PATH/beaglebone/beaglebone_black_debian_sdcard-${UBOOT_MENDER_BRANCH_BBB}.tar
+        --key $S3_BUCKET_PATH_UBOOT/beaglebone/beaglebone_black_debian_sdcard-${UBOOT_MENDER_BRANCH_BBB}.tar
     - echo "Publishing uboot for raspberrypi0w version ${UBOOT_MENDER_BRANCH_RPI}"
     - aws s3 cp output/raspberrypi0w-${UBOOT_MENDER_BRANCH_RPI}.tar.gz
-        s3://$S3_BUCKET_NAME/$S3_BUCKET_PATH/raspberrypi/raspberrypi0w-${UBOOT_MENDER_BRANCH_RPI}.tar.gz
+        s3://$S3_BUCKET_NAME/$S3_BUCKET_PATH_UBOOT/raspberrypi/raspberrypi0w-${UBOOT_MENDER_BRANCH_RPI}.tar.gz
     - aws s3api put-object-acl --acl public-read --bucket $S3_BUCKET_NAME
-        --key $S3_BUCKET_PATH/raspberrypi/raspberrypi0w-${UBOOT_MENDER_BRANCH_RPI}.tar.gz
+        --key $S3_BUCKET_PATH_UBOOT/raspberrypi/raspberrypi0w-${UBOOT_MENDER_BRANCH_RPI}.tar.gz
     - echo "Publishing uboot for raspberrypi3 version ${UBOOT_MENDER_BRANCH_RPI}"
     - aws s3 cp output/raspberrypi3-${UBOOT_MENDER_BRANCH_RPI}.tar.gz
-        s3://$S3_BUCKET_NAME/$S3_BUCKET_PATH/raspberrypi/raspberrypi3-${UBOOT_MENDER_BRANCH_RPI}.tar.gz
+        s3://$S3_BUCKET_NAME/$S3_BUCKET_PATH_UBOOT/raspberrypi/raspberrypi3-${UBOOT_MENDER_BRANCH_RPI}.tar.gz
     - aws s3api put-object-acl --acl public-read --bucket $S3_BUCKET_NAME
-        --key $S3_BUCKET_PATH/raspberrypi/raspberrypi3-${UBOOT_MENDER_BRANCH_RPI}.tar.gz
+        --key $S3_BUCKET_PATH_UBOOT/raspberrypi/raspberrypi3-${UBOOT_MENDER_BRANCH_RPI}.tar.gz
     - echo "Publishing uboot for raspberrypi4 version ${UBOOT_MENDER_BRANCH_RPI}"
     - aws s3 cp output/raspberrypi4-${UBOOT_MENDER_BRANCH_RPI}.tar.gz
-        s3://$S3_BUCKET_NAME/$S3_BUCKET_PATH/raspberrypi/raspberrypi4-${UBOOT_MENDER_BRANCH_RPI}.tar.gz
+        s3://$S3_BUCKET_NAME/$S3_BUCKET_PATH_UBOOT/raspberrypi/raspberrypi4-${UBOOT_MENDER_BRANCH_RPI}.tar.gz
     - aws s3api put-object-acl --acl public-read --bucket $S3_BUCKET_NAME
-        --key $S3_BUCKET_PATH/raspberrypi/raspberrypi4-${UBOOT_MENDER_BRANCH_RPI}.tar.gz
+        --key $S3_BUCKET_PATH_UBOOT/raspberrypi/raspberrypi4-${UBOOT_MENDER_BRANCH_RPI}.tar.gz
+    # GRUB EFI binaries
+    - echo "Publishing grub-efi for x86-64"
+    - aws s3 cp grub-efi/output/grub-efi-bootx64.efi
+        s3://$S3_BUCKET_NAME/$S3_BUCKET_PATH_GRUB/$GRUB_VERSION/x86-64/grub-efi-bootx64.efi
+    - aws s3api put-object-acl --acl public-read --bucket $S3_BUCKET_NAME
+        --key $S3_BUCKET_PATH_GRUB/$GRUB_VERSION/x86-64/grub-efi-bootx64.efi
+    - aws s3 cp grub-efi/output/x86-64/bin/grub-editenv
+        s3://$S3_BUCKET_NAME/$S3_BUCKET_PATH_GRUB/$GRUB_VERSION/x86-64/grub-editenv
+    - aws s3api put-object-acl --acl public-read --bucket $S3_BUCKET_NAME
+        --key $S3_BUCKET_PATH_GRUB/$GRUB_VERSION/x86-64/grub-editenv
+    - echo "Publishing grub-efi for arm"
+    - aws s3 cp grub-efi/output/grub-efi-bootarm.efi
+        s3://$S3_BUCKET_NAME/$S3_BUCKET_PATH_GRUB/$GRUB_VERSION/arm/grub-efi-bootarm.efi
+    - aws s3api put-object-acl --acl public-read --bucket $S3_BUCKET_NAME
+        --key $S3_BUCKET_PATH_GRUB/$GRUB_VERSION/arm/grub-efi-bootarm.efi
+    - aws s3 cp grub-efi/output/arm/bin/grub-editenv
+        s3://$S3_BUCKET_NAME/$S3_BUCKET_PATH_GRUB/$GRUB_VERSION/arm/grub-editenv
+    - aws s3api put-object-acl --acl public-read --bucket $S3_BUCKET_NAME
+        --key $S3_BUCKET_PATH_GRUB/$GRUB_VERSION/arm/grub-editenv
+    - aws s3 cp grub-efi/output/grub-efi-bootaa64.efi
+        s3://$S3_BUCKET_NAME/$S3_BUCKET_PATH_GRUB/$GRUB_VERSION/aarch64/grub-efi-bootaa64.efi
+    - aws s3api put-object-acl --acl public-read --bucket $S3_BUCKET_NAME
+        --key $S3_BUCKET_PATH_GRUB/$GRUB_VERSION/aarch64/grub-efi-bootaa64.efi
+    - aws s3 cp grub-efi/output/aarch64/bin/grub-editenv
+        s3://$S3_BUCKET_NAME/$S3_BUCKET_PATH_GRUB/$GRUB_VERSION/aarch64/grub-editenv
+    - aws s3api put-object-acl --acl public-read --bucket $S3_BUCKET_NAME
+        --key $S3_BUCKET_PATH_GRUB/$GRUB_VERSION/aarch64/grub-editenv
   only:
     - /^(master|[0-9]+\.[0-9]+\.x)$/

--- a/grub-efi/Dockerfile.aarch64
+++ b/grub-efi/Dockerfile.aarch64
@@ -1,0 +1,19 @@
+FROM debian:stretch
+
+RUN apt-get update -q && \
+    apt-get install -qy crossbuild-essential-arm64 python wget bison flex
+
+ARG GRUB_VERSION=none
+RUN if [ "$GRUB_VERSION" = none ]; then echo "GRUB_VERSION must be set!" 1>&2; exit 1; fi
+
+RUN wget --progress=dot:mega ftp://ftp.gnu.org/gnu/grub/grub-${GRUB_VERSION}.tar.gz && \
+    tar -xf grub-${GRUB_VERSION}.tar.gz
+
+WORKDIR grub-${GRUB_VERSION}
+
+RUN ./configure \
+    --prefix=/install \
+    --with-platform=efi \
+    --host aarch64-linux-gnu
+RUN make
+RUN make install

--- a/grub-efi/Dockerfile.arm
+++ b/grub-efi/Dockerfile.arm
@@ -1,0 +1,19 @@
+FROM debian:stretch
+
+RUN apt-get update -q && \
+    apt-get install -qy crossbuild-essential-armhf python wget bison flex
+
+ARG GRUB_VERSION=none
+RUN if [ "$GRUB_VERSION" = none ]; then echo "GRUB_VERSION must be set!" 1>&2; exit 1; fi
+
+RUN wget --progress=dot:mega ftp://ftp.gnu.org/gnu/grub/grub-${GRUB_VERSION}.tar.gz && \
+    tar -xf grub-${GRUB_VERSION}.tar.gz
+
+WORKDIR grub-${GRUB_VERSION}
+
+RUN ./configure \
+    --prefix=/install \
+    --with-platform=efi \
+    --host arm-linux-gnueabihf
+RUN make
+RUN make install

--- a/grub-efi/Dockerfile.x86-64
+++ b/grub-efi/Dockerfile.x86-64
@@ -1,0 +1,18 @@
+FROM debian:stretch
+
+RUN apt-get update -q && \
+    apt-get install -qy build-essential python wget bison flex
+
+ARG GRUB_VERSION=none
+RUN if [ "$GRUB_VERSION" = none ]; then echo "GRUB_VERSION must be set!" 1>&2; exit 1; fi
+
+RUN wget --progress=dot:mega ftp://ftp.gnu.org/gnu/grub/grub-${GRUB_VERSION}.tar.gz && \
+    tar -xf grub-${GRUB_VERSION}.tar.gz
+
+WORKDIR grub-${GRUB_VERSION}
+
+RUN ./configure \
+    --prefix=/install \
+    --with-platform=efi
+RUN make
+RUN make install

--- a/grub-efi/docker-create-grub-efi-binaries
+++ b/grub-efi/docker-create-grub-efi-binaries
@@ -1,0 +1,64 @@
+#!/bin/sh
+
+set -e
+
+GRUB_VERSION=${GRUB_VERSION:-2.04}
+
+GRUB_MODULES="boot linux ext2 fat serial part_msdos part_gpt normal \
+              efi_gop iso9660 configfile search loadenv test \
+              cat echo gcry_sha256 halt hashsum sleep reboot"
+
+sudo rm -rf output
+
+for arch in x86-64 arm aarch64; do
+    mkdir -p output/$arch
+    echo -n "Building binaries for $arch..."
+    docker_build_ret=0
+    docker build \
+           -f Dockerfile.$arch \
+           -t grub-efi:$arch \
+           --build-arg GRUB_VERSION=${GRUB_VERSION} \
+           . > /tmp/docker-build.log || docker_build_ret=$?
+    if [ $docker_build_ret -ne 0 ]; then
+        echo " failed!"
+        tail -n 100 /tmp/docker-build.log
+        exit $docker_build_ret
+    else
+        echo " done"
+    fi
+    echo -n "Extracting binaries for $arch..."
+    docker run --rm --entrypoint "/bin/sh" \
+        -v $(pwd)/output/$arch:/export grub-efi:$arch \
+        -c "cp -r /install/* /export"
+    echo " done"
+done
+
+sudo chown -R $(id -u):$(id -g) output/*
+
+echo "Generating EFI boot images"
+
+output_dir=$(pwd)/output
+grub_mkimage_native=${output_dir}/x86-64/bin/grub-mkimage
+
+set -x
+
+$grub_mkimage_native \
+    -p /EFI/BOOT \
+    -d ${output_dir}/x86-64/lib/grub/x86_64-efi \
+    -O x86_64-efi \
+    -o ${output_dir}/grub-efi-bootx64.efi \
+    $GRUB_MODULES
+
+$grub_mkimage_native \
+    -p /EFI/BOOT \
+    -d ${output_dir}/arm/lib/grub/arm-efi \
+    -O arm-efi \
+    -o ${output_dir}/grub-efi-bootarm.efi \
+    $GRUB_MODULES
+
+$grub_mkimage_native \
+    -p /EFI/BOOT \
+    -d ${output_dir}/aarch64/lib/grub/arm64-efi \
+    -O arm64-efi \
+    -o ${output_dir}/grub-efi-bootaa64.efi \
+    $GRUB_MODULES


### PR DESCRIPTION
```
MEN-2791: Generate and publish grub-efi binaries
    
GRUB is cross built from source for the three archs inside Docker, then
the grub-editenv and the generated EFI boot images are extracted
outside.
    
All the binaries are published into the existing S3 bucket following the
path .../grub-efi/<version>/<arch>/grub-editenv,<boot-img>.efi
```
