### PR TITLE
MEN-2404: Reintroduce GRUB 2.04.

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,5 +1,5 @@
 variables:
-  GRUB_VERSION: '2.02'
+  GRUB_VERSION: '2.04'
   DOCKER_REPOSITORY: mendersoftware/mender-convert-integration-scripts
   S3_BUCKET_NAME: mender
 

--- a/grub-efi/docker-create-grub-efi-binaries
+++ b/grub-efi/docker-create-grub-efi-binaries
@@ -2,7 +2,7 @@
 
 set -e
 
-GRUB_VERSION=${GRUB_VERSION:-2.02}
+GRUB_VERSION=${GRUB_VERSION:-2.04}
 
 GRUB_MODULES="boot linux ext2 fat serial part_msdos part_gpt normal \
               efi_gop iso9660 configfile search loadenv test \


### PR DESCRIPTION
The problems of GRUB 2.04 have been identified and fixed.

This reverts commit 872f2ca284a8ae1e41381982496e56e383d3f81e.

Signed-off-by: Kristian Amlie <kristian.amlie@northern.tech>