### PR TITLE
[pipeline] Set docker:dind image to a fixed version

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -18,7 +18,7 @@ build:uboot:
   stage: build
   image: docker
   services:
-    - docker:dind
+    - docker:19.03.5-dind
   script:
     - IMAGE_NAME=$DOCKER_REPOSITORY:pr ./docker-create-integration-binaries
   artifacts:
@@ -30,7 +30,7 @@ build:grub-efi:
   stage: build
   image: docker
   services:
-    - docker:dind
+    - docker:19.03.5-dind
   before_script:
     - apk --update --no-cache add libc6-compat
   script:


### PR DESCRIPTION
So that we can workaround a temporary issue with latest docker:dind

See MEN-3200

See https://gitlab.com/gitlab-com/support-forum/issues/5194#note_288438588

Changelog: None

Signed-off-by: Lluis Campos <lluis.campos@northern.tech>