### PR TITLE
grub-efi: Enable regexp module.

### DIFF
--- a/grub-efi/docker-create-grub-efi-binaries
+++ b/grub-efi/docker-create-grub-efi-binaries
@@ -6,7 +6,7 @@ GRUB_VERSION=${GRUB_VERSION:-2.04}
 
 GRUB_MODULES="boot linux ext2 fat serial part_msdos part_gpt normal \
               efi_gop iso9660 configfile search loadenv test \
-              cat echo gcry_sha256 halt hashsum sleep reboot"
+              cat echo gcry_sha256 halt hashsum sleep reboot regexp"
 
 rm -rf output
 


### PR DESCRIPTION
This is used for dynamically determining the root device.

Changelog: Title
Signed-off-by: Drew Moseley <drew.moseley@northern.tech>