### PR TITLE
Enable U-Boot to select between compressed and uncompressed Kernels

### DIFF
--- a/build-uboot-rpi.sh
+++ b/build-uboot-rpi.sh
@@ -60,8 +60,13 @@ cat <<- 'EOF' > boot.cmd
 fdt addr ${fdt_addr} && fdt get value bootargs /chosen bootargs
 run mender_setup
 mmc dev ${mender_uboot_dev}
-load ${mender_uboot_root} ${kernel_addr_r} /boot/zImage
-bootz ${kernel_addr_r} - ${fdt_addr}
+if load ${mender_uboot_root} ${kernel_addr_r} /boot/zImage; then
+    bootz ${kernel_addr_r} - ${fdt_addr}
+elif load ${mender_uboot_root} ${kernel_addr_r} /boot/uImage; then
+    bootm ${kernel_addr_r} - ${fdt_addr}
+else
+    echo "No bootable Kernel found."
+fi
 run mender_try_to_recover
 
 # Recompile with:


### PR DESCRIPTION
Changelog: Instruct U-Boot to be able to boot either a compressed or an uncompressed kernel. This is very useful e.g. when switching from Debian (Raspbian) created using mender-convert to a Yocto based environment that does not compress the Kernel by default.

Signed-off-by: Simon Ensslen <sensslen@gmail.com>